### PR TITLE
Fixed user client error when a server they are attached to is disconnected/shutdown.

### DIFF
--- a/mk2/user_client.py
+++ b/mk2/user_client.py
@@ -477,13 +477,13 @@ class UserClientFactory(ClientFactory):
         return self.client
 
     def switch_server(self, delta=1):
+        index = self.servers.index(self.client.name)
         self.update_servers()
         if len(self.servers) == 0:  # no running servers
             return self.ui.stop()
         if len(self.servers) == 1:  # don't switch with only one server
             return
 
-        index = self.servers.index(self.client.name)
         name = self.servers[(index + delta) % len(self.servers)]
         self.connect_to_server(name)
 


### PR DESCRIPTION
This PR fixes: http://supa.me/jnX6Ey.png which is caused when a server that a user client is attached to is shutdown/disconnected.

I have only tested very briefly, but I no longer get the error when a server I'm attached to is shutdown.
