### PR TITLE
Fixed error when reading blank pid file.

### DIFF
--- a/mk2/launcher.py
+++ b/mk2/launcher.py
@@ -142,7 +142,11 @@ class CommandTyStateful(Command):
         o = []
         for path in glob.glob(self.shared('pid', '*')):
             with open(path) as fp:
-                pid = int(fp.read())
+                pid_string = fp.read()
+                if pid_string == "":  # If the pid file is blank.
+                    os.remove(path)
+                    continue
+                pid = int(pid_string)
                 try:
                     os.kill(pid, 0)
                 except OSError as err:


### PR DESCRIPTION
The error reported in issue #80 was caused by an erroneous blank pid file being stored. This caused mark2 to attempt to cast an empty string to an integer and thus crash. This commit fixes that error by removing blank pid files when they are encountered, similar to how nonexistent pids are handled.