### PR TITLE
Fixed error in default config.

### DIFF
--- a/mk2/resources/mark2.default.properties
+++ b/mk2/resources/mark2.default.properties
@@ -142,7 +142,7 @@ java.cli.D.jline.terminal=jline.UnsupportedTerminal
 #java.cli.XX.UseThreadPriorities=true
 
 # Extra java arguments
-java.cli-extra=
+java.cli_extra=
 
 ###
 ### Plugins


### PR DESCRIPTION
This should be an underscore, using it as provided causes mark2 to ignore the option.

Compare with:
./mk2/events/__init__.py:52
./mk2/plugins/__init__.py:155
./mk2/properties.py:182
./mk2/properties.py:183
./samples/bungeecord/mark2.properties:22