### PR TITLE
Disable setting the user's umask insecurely

### DIFF
--- a/mk2/launcher.py
+++ b/mk2/launcher.py
@@ -349,7 +349,6 @@ class CommandStart(CommandTyTerminal):
 
         os.chdir(".")
         os.setsid()
-        os.umask(0)
 
         if os.fork() > 0:
             sys.exit(0)


### PR DESCRIPTION
IMO this is a fairly substantial security problem. 

For example, if you download minecraft and launch it with mark2 for the first time, all of the folders/config/world/everything will be set to world-writeable. This... is really bad. The user should be able to decide this if they want it by setting their own umask before invoking mark2.

I'll understand if you don't want to merge this, but I wanted to at least submit the request. I think the benefit to people who have their system configured properly far outweighs the potential complaints from new people. 