### PR TITLE
Support `java.cli_prepend` as first JVM options added.

### DIFF
--- a/mk2/properties.py
+++ b/mk2/properties.py
@@ -160,6 +160,8 @@ class Mark2Properties(Properties):
 
     def get_jvm_options(self):
         options = []
+        if self.get('java.cli_prepend', '') != '':
+            options.extend(shlex.split(self['java.cli_prepend']))
         for k, v in self.iteritems():
             m = re.match('^java\.cli\.([^\.]+)\.(.+)$', k)
             if m:

--- a/mk2/resources/mark2.default.properties
+++ b/mk2/resources/mark2.default.properties
@@ -141,7 +141,10 @@ java.cli.D.jline.terminal=jline.UnsupportedTerminal
 #java.cli.XX.UseStringCache=true
 #java.cli.XX.UseThreadPriorities=true
 
-# Extra java arguments
+# Extra java arguments prepended before all others
+java.cli_prepend=
+
+# Extra java arguments appended after all others
 java.cli_extra=
 
 ###


### PR DESCRIPTION
We'd like to try to follow Aikar's advice on GC tuning options, stated [here](https://aikar.co/2018/07/02/tuning-the-jvm-g1gc-garbage-collector-flags-for-minecraft/). But expressing those options with `java.cli.XX.` settings in `mark2.properties` is impossible because `dict` order is arbitrary.

The JVM is unhappy if `-XX:+UnlockExperimentalVMOptions` does not precede the experimental options.
```
2019-02-23 01:07:46 # jvm options: -XX:+ParallelRefProcEnabled -Xms2G -Xmx2G -Djline.terminal=jline.UnsupportedTerminal -XX:G1MixedGCLiveThresholdPercent=35 -XX:G1MaxNewSizePercent=80 -XX:TargetSurvivorRatio=90 -XX:+DisableExplicitGC -XX:MaxGCPauseMillis=100 -XX:G1NewSizePercent=50 -XX:+AlwaysPreTouch -XX:+UseG1GC
2019-02-23 01:07:46 | [RAW] Error: VM option 'G1MixedGCLiveThresholdPercent' is experimental and must be enabled via -XX:+UnlockExperimentalVMOptions.
2019-02-23 01:07:46 | [RAW] Error: The unlock option must precede 'G1MixedGCLiveThresholdPercent'.
2019-02-23 01:07:46 | [RAW] Error: Could not create the Java Virtual Machine.
2019-02-23 01:07:46 | [RAW] Error: A fatal exception has occurred. Program will exit.
2019-02-23 01:07:46 # fatal error: A process has ended with a probable error condition: process ended with exit code 1.
2019-02-23 01:07:46 # mark2 stopped.
```

I don't know the `mark2` code base well enough to derive `Properties` from `collection.OrderedDict` - `mark2` locks up on start. Something to do with the way iteration is handled, I guess.

This PR adds the configuration property `java.cli_prepend=<shell-quoted-jvm-args>` so that Aikar's options can be expressed as:

```# From: https://aikar.co/2018/07/02/tuning-the-jvm-g1gc-garbage-collector-flags-for-minecraft/
java.cli_prepend=-XX:+UnlockExperimentalVMOptions     
java.cli.XX.UseG1GC=true
java.cli.XX.MaxGCPauseMillis=100
java.cli.XX.DisableExplicitGC=true
java.cli.XX.TargetSurvivorRatio=90
java.cli.XX.G1NewSizePercent=50
java.cli.XX.G1MaxNewSizePercent=80
java.cli.XX.G1MixedGCLiveThresholdPercent=35
java.cli.XX.AlwaysPreTouch=true
java.cli.XX.ParallelRefProcEnabled=true
```
