### PR TITLE
Update INSTALL.md to remove python 3 install cmds

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,8 +16,8 @@
 
 This should suffice:
 
-    $ sudo apt-get install git libssl-dev python-dev python3-pip
-    $ sudo pip3 install -r requirements.txt
+    $ sudo apt-get install git libssl-dev python-dev python-pip
+    $ sudo pip install -r requirements.txt
     
 ### arch
 


### PR DESCRIPTION
Reverted bad changes to the install guide that causes issues with mark2 and python 3. There are issues with Twisted because this small change to the install guide makes it install the python 3 versions of twisted (and other modules used).