### PR TITLE
Added a config option to point to a lang file for console tracking (Fixes PlayerDeath events)

### DIFF
--- a/mk2/properties.py
+++ b/mk2/properties.py
@@ -1,5 +1,6 @@
 import os
 import re
+import json
 import shlex
 import zipfile
 from functools import reduce
@@ -61,7 +62,6 @@ class Properties(OrderedDict):
         def parse(inp):
             token = list(inp)
             out = ""
-            uni = False
             while len(token) > 0:
                 c = token.pop(0)
                 if c == '\\':
@@ -86,6 +86,18 @@ class Properties(OrderedDict):
                     out += c
 
             return out
+        
+        # Try to load the file as json
+        if f.name.endswith(".json"):
+            try:
+                _json = json.load(f)
+                for k, v in _json.items():
+                    self[k] = v
+                print("Loaded properties from input file as json")
+                f.close()
+                return
+            except json.JSONDecodeError:
+                pass
         
         if f.mode == "rb":
             d = f.read().decode('utf-8')

--- a/mk2/resources/mark2.default.properties
+++ b/mk2/resources/mark2.default.properties
@@ -95,6 +95,10 @@ mark2.service.process.java-path=java
 # Example: mark2.service.process.server-args=--max-players 36 --world map_name
 mark2.service.process.server-args=
 
+# Console tracking: service that handles console messages to trigger player events
+# Lang file path: Path to a .json or .lang file containing the messages for minecraft stuff (and in mark2's case, the death messages)
+mark2.service.console_tracking.lang_file_path=
+
 ###
 ### JVM options
 ###

--- a/mk2/services/console_tracking.py
+++ b/mk2/services/console_tracking.py
@@ -7,11 +7,15 @@ from mk2.plugins import Plugin
 
 
 class ConsoleTracking(Plugin):
+    lang_file_path = Plugin.Property(default=None)
     deaths = tuple()
     chat_events = tuple()
 
     def setup(self):
-        lang = properties.load_jar(self.parent.jar_file, 'assets/minecraft/lang/en_US.lang', 'lang/en_US.lang')
+        if self.lang_file_path is None:
+            lang = properties.load_jar(self.parent.jar_file, 'assets/minecraft/lang/en_US.lang', 'lang/en_US.lang', "assets/minecraft/lang/en_us.json")
+        else:
+            lang = properties.load(properties.Lang, self.lang_file_path)
         if lang is not None:
             self.deaths = tuple(lang.get_deaths())
             self.register(self.death_handler, ServerOutput, pattern=".*")


### PR DESCRIPTION
This will fix player death events not being triggered in mark2.

To get a lang file for your Minecraft version, open the server jar in an archive manager (WinRAR, 7Zip etc.) and look for `assets/minecraft/lang/en_us.json` it could also be a `.lang` file. Place that somewhere on the server and point the config option to this file.

`mark2.service.console_tracking.lang_file_path=/path/to/lang/file/en_us.json`

