### PR TITLE
Fix ~mark2CrashCheck~<---HERE console spam

### DIFF
--- a/mk2/plugins/monitor.py
+++ b/mk2/plugins/monitor.py
@@ -148,7 +148,6 @@ class Monitor(Plugin):
 
     # crash
     def handle_crash_ok(self, event):
-        self.console("Regex for crash check command: " + self.crash_check_command_message)
         self.checks["crash"].reset()
         return Event.EAT | Event.UNREGISTER
 

--- a/mk2/plugins/monitor.py
+++ b/mk2/plugins/monitor.py
@@ -58,7 +58,7 @@ class Monitor(Plugin):
     crash_warn     = Plugin.Property(default=0)
     crash_unknown_cmd_message    = Plugin.Property(default="Unknown.*command.*")
     crash_check_command          = Plugin.Property(default="")
-    crash_check_command_message  = Plugin.Property(default=".*{}.*".format(crash_check_command.coerce()))
+    crash_check_command_message  = Plugin.Property(default="")
 
     oom_enabled          = Plugin.Property(default=True)
     crash_report_enabled = Plugin.Property(default=True)
@@ -150,10 +150,6 @@ class Monitor(Plugin):
     def handle_crash_ok(self, event):
         self.console("Regex for crash check command: " + self.crash_check_command_message)
         self.checks["crash"].reset()
-        return Event.EAT | Event.UNREGISTER
-
-    # eats the console output for the crash check command
-    def eat_crash_check(self, event):
         return Event.EAT | Event.UNREGISTER
 
     # out of memory

--- a/mk2/plugins/monitor.py
+++ b/mk2/plugins/monitor.py
@@ -58,7 +58,7 @@ class Monitor(Plugin):
     crash_warn     = Plugin.Property(default=0)
     crash_unknown_cmd_message    = Plugin.Property(default="Unknown.*command.*")
     crash_check_command          = Plugin.Property(default="")
-    crash_check_command_message  = Plugin.Property(default=".*{}.*".format(crash_check_command))
+    crash_check_command_message  = Plugin.Property(default=".*{}.*".format(crash_check_command.coerce()))
 
     oom_enabled          = Plugin.Property(default=True)
     crash_report_enabled = Plugin.Property(default=True)

--- a/mk2/plugins/monitor.py
+++ b/mk2/plugins/monitor.py
@@ -57,7 +57,8 @@ class Monitor(Plugin):
     crash_timeout  = Plugin.Property(default=3)
     crash_warn     = Plugin.Property(default=0)
     crash_unknown_cmd_message    = Plugin.Property(default="Unknown.*command.*")
-    crash_check_command    = Plugin.Property(default="")
+    crash_check_command          = Plugin.Property(default="")
+    crash_check_command_message  = Plugin.Property(default=".*{}.*".format(crash_check_command))
 
     oom_enabled          = Plugin.Property(default=True)
     crash_report_enabled = Plugin.Property(default=True)
@@ -80,7 +81,7 @@ class Monitor(Plugin):
 
         if self.crash_report_enabled:
             self.register(self.handle_unknown_crash, ServerOutput, level='ERROR', pattern='This crash report has been saved to.*')
-        
+
         if self.jvm_crash_enabled:
             self.register(self.handle_jvm_crash, ServerOutput, level='RAW', pattern='.*A fatal error has been detected by the Java Runtime Environment:.*')
 
@@ -134,19 +135,27 @@ class Monitor(Plugin):
             self.register(self.handle_crash_ok, ServerOutput,
                           pattern=self.crash_unknown_cmd_message,
                           track=False)
+            self.register(self.handle_crash_ok, ServerOutput,
+                          pattern=self.crash_check_command_message,
+                          track=False)
             self.send(self.crash_check_command)  # Blank command to trigger 'Unknown command'
-    
+
     def reset_counts(self):
         for c in self.checks.values():
             c.reset()
 
     ### handlers
-    
+
     # crash
     def handle_crash_ok(self, event):
+        self.console("Regex for crash check command: " + self.crash_check_command_message)
         self.checks["crash"].reset()
         return Event.EAT | Event.UNREGISTER
-    
+
+    # eats the console output for the crash check command
+    def eat_crash_check(self, event):
+        return Event.EAT | Event.UNREGISTER
+
     # out of memory
     def handle_oom(self, event):
         self.console('server out of memory, restarting...')
@@ -154,7 +163,7 @@ class Monitor(Plugin):
                                   data="server ran out of memory",
                                   priority=1))
         self.dispatch(ServerStop(reason='out of memory', respawn=ServerStop.RESTART))
-    
+
     # unknown crash
     def handle_unknown_crash(self, event):
         self.console('server crashed for unknown reason, restarting...')
@@ -162,7 +171,7 @@ class Monitor(Plugin):
                                   data="server crashed for unknown reason",
                                   priority=1))
         self.dispatch(ServerStop(reason='unknown reason', respawn=ServerStop.RESTART))
-    
+
     # jvm crash
     def handle_jvm_crash(self, event):
         self.console('server jvm crashed, restarting...')
@@ -170,12 +179,12 @@ class Monitor(Plugin):
                                   data="server jvm crashed",
                                   priority=1))
         self.dispatch(ServerStop(reason='jvm crash', respawn=ServerStop.RESTART))
-    
+
     # ping
     def handle_ping(self, event):
         if event.source == 'ping':
             self.checks["ping"].reset()
-    
+
     # pcount
     def handle_pcount(self, event):
         if event.players_current > 0:

--- a/mk2/resources/mark2.default.properties
+++ b/mk2/resources/mark2.default.properties
@@ -346,7 +346,8 @@ plugin.monitor.crash-timeout=1
 plugin.monitor.crash-warn=0
 plugin.monitor.crash-unknown-cmd-message=Unknown.*command.*
 plugin.monitor.crash-check-command=/~mark2CrashCheck~
-plugin.monitor.crash-check-command-message=.*/~mark2CrashCheck~.*
+# For newer MC versions, this will filter out the second "~mark2CrashCheck<---HERE" line
+plugin.monitor.crash-check-command-message=.*~mark2CrashCheck~.*
 
 # Periodically make sure the server is still accepting connections
 plugin.monitor.ping-enabled=true

--- a/mk2/resources/mark2.default.properties
+++ b/mk2/resources/mark2.default.properties
@@ -344,8 +344,9 @@ plugin.monitor.enabled=true
 plugin.monitor.crash-enabled=true
 plugin.monitor.crash-timeout=1
 plugin.monitor.crash-warn=0
-plugin.monitor.crash-unknown-cmd-message=Unknown command.*
+plugin.monitor.crash-unknown-cmd-message=Unknown.*command.*
 plugin.monitor.crash-check-command=/~mark2CrashCheck~
+plugin.monitor.crash-check-command-message=.*/~mark2CrashCheck~.*
 
 # Periodically make sure the server is still accepting connections
 plugin.monitor.ping-enabled=true


### PR DESCRIPTION
Added a new config option and filter for the line that prints after an unknown command is sent containing the mark2 crash check command

![image](https://github.com/user-attachments/assets/eb4c33a8-a7d9-4fea-a1ee-b3622dee842b)
